### PR TITLE
refactor: change group & namespace

### DIFF
--- a/jindong/build.gradle.kts
+++ b/jindong/build.gradle.kts
@@ -23,12 +23,12 @@ plugins {
     alias(libs.plugins.ksp)
 }
 
-group = "io.github.jindong"
+group = "io.github.compose-jindong"
 version = "1.0.0"
 
 kotlin {
     androidLibrary {
-        namespace = "io.github.jindong"
+        namespace = "io.github.compose.jindong"
         compileSdk = libs.versions.android.compileSdk.get().toInt()
         minSdk = libs.versions.android.minSdk.get().toInt()
 

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/compose/JindongApplier.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/compose/JindongApplier.kt
@@ -13,10 +13,10 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.compose
+package io.github.compose.jindong.compose
 
 import androidx.compose.runtime.AbstractApplier
-import io.github.jindong.node.HapticNode
+import io.github.compose.jindong.node.HapticNode
 
 /**
  * Applier that manages the haptic node tree for Compose Runtime.

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/DelayNode.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/DelayNode.kt
@@ -13,19 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
- * Represents a scheduled haptic event with absolute timing.
+ * A leaf node representing a time delay with no haptic output.
  *
- * @property startTimeMs Absolute start time in milliseconds (relative to pattern start)
- * @property durationMs Duration of the haptic event in milliseconds
- * @property intensity Vibration intensity from 0.0 to 1.0
- * @property iosParameters iOS Core Haptics parameters (ignored on Android)
+ * This node has no children and returns an empty list when [collectEvents] is called.
+ * The duration is used by parent nodes (e.g., [SequenceNode]) to advance timing.
+ *
+ * @property durationMs Duration of the delay in milliseconds
  */
-internal data class ScheduledHapticEvent(
-  val startTimeMs: Long,
+internal class DelayNode(
   val durationMs: Long,
-  val intensity: Float,
-  val iosParameters: IosHapticParameters? = null,
-)
+) : HapticNode {
+  override val children: MutableList<HapticNode> = mutableListOf()
+
+  override fun collectEvents(startTimeMs: Long): List<ScheduledHapticEvent> = emptyList()
+}

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/HapticEventNode.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/HapticEventNode.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
  * A leaf node representing a single haptic event (vibration).

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/HapticNode.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/HapticNode.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
  * Base interface for all haptic nodes in the composition tree.

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/IosHapticParameters.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/IosHapticParameters.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import kotlin.time.Duration
 

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/RepeatNode.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/RepeatNode.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
  * A container node that repeats its children N times sequentially.

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/ScheduledHapticEvent.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/ScheduledHapticEvent.kt
@@ -13,20 +13,19 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
- * A leaf node representing a time delay with no haptic output.
+ * Represents a scheduled haptic event with absolute timing.
  *
- * This node has no children and returns an empty list when [collectEvents] is called.
- * The duration is used by parent nodes (e.g., [SequenceNode]) to advance timing.
- *
- * @property durationMs Duration of the delay in milliseconds
+ * @property startTimeMs Absolute start time in milliseconds (relative to pattern start)
+ * @property durationMs Duration of the haptic event in milliseconds
+ * @property intensity Vibration intensity from 0.0 to 1.0
+ * @property iosParameters iOS Core Haptics parameters (ignored on Android)
  */
-internal class DelayNode(
+internal data class ScheduledHapticEvent(
+  val startTimeMs: Long,
   val durationMs: Long,
-) : HapticNode {
-  override val children: MutableList<HapticNode> = mutableListOf()
-
-  override fun collectEvents(startTimeMs: Long): List<ScheduledHapticEvent> = emptyList()
-}
+  val intensity: Float,
+  val iosParameters: IosHapticParameters? = null,
+)

--- a/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/SequenceNode.kt
+++ b/jindong/src/commonMain/kotlin/io/github/compose/jindong/node/SequenceNode.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 /**
  * A container node that executes its children sequentially.

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/compose/JindongApplierTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/compose/JindongApplierTest.kt
@@ -15,12 +15,12 @@
  */
 @file:OptIn(ExperimentalComposeApi::class)
 
-package io.github.jindong.compose
+package io.github.compose.jindong.compose
 
 import androidx.compose.runtime.ExperimentalComposeApi
-import io.github.jindong.node.HapticEventNode
-import io.github.jindong.node.HapticNode
-import io.github.jindong.node.SequenceNode
+import io.github.compose.jindong.node.HapticEventNode
+import io.github.compose.jindong.node.HapticNode
+import io.github.compose.jindong.node.SequenceNode
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.collections.shouldBeEmpty

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/DelayNodeTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/DelayNodeTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/HapticEventNodeTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/HapticEventNodeTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/RepeatNodeTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/RepeatNodeTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.assertions.throwables.shouldThrow

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/ScheduledHapticEventTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/ScheduledHapticEventTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec

--- a/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/SequenceNodeTest.kt
+++ b/jindong/src/commonTest/kotlin/io/github/compose/jindong/node/SequenceNodeTest.kt
@@ -13,7 +13,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package io.github.jindong.node
+package io.github.compose.jindong.node
 
 import io.kotest.assertions.assertSoftly
 import io.kotest.core.spec.style.FunSpec


### PR DESCRIPTION
## Issue

<!-- Link the related issue(s) -->
close #18

## Summary
<!-- Briefly describe what this PR does -->

During the new namespace verification process on Maven Central, ownership of the namespace is required. As we do not have ownership of io.github.jindong, we are registering a new namespace, io.github.compose-jindong, and migrating the package names and group IDs based on this new namespace.

- Change group & namespace
  - io.github.jindong -> io.github.compose.jindong


### Implementation Highlights (Optional)
<!-- Explain key technical decisions, patterns, or algorithms -->
<!-- What should reviewers pay attention to? -->


<!-- Test Results are handled by CI-->
<!-- ## Test Results -->

## Additional Context (Optional)
<!-- Any other context, design decisions, or references -->

