### PR TITLE
:thread: fix memory visibility in AndroidHapticHandle

### DIFF
--- a/jindong/src/androidMain/kotlin/io/github/compose/jindong/executor/HapticExecutor.android.kt
+++ b/jindong/src/androidMain/kotlin/io/github/compose/jindong/executor/HapticExecutor.android.kt
@@ -26,6 +26,7 @@ import androidx.annotation.RequiresPermission
 import io.github.compose.jindong.model.HapticPattern
 import io.github.compose.jindong.model.ScheduledHapticEvent
 import kotlinx.coroutines.delay
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Android implementation of [HapticExecutor] using [VibrationEffect.createWaveform].
@@ -79,7 +80,8 @@ internal class DefaultAndroidHapticExecutor(context: Context) : HapticExecutor {
   @RequiresPermission(Manifest.permission.VIBRATE)
   private fun vibratePattern(pattern: HapticPattern) {
     val waveform = pattern.toWaveform()
-    val vibrationEffect = VibrationEffect.createWaveform(waveform.timings, waveform.amplitudes, -1)
+    val vibrationEffect =
+      VibrationEffect.createWaveform(waveform.timings, waveform.amplitudes, -1)
     vibrator.vibrate(vibrationEffect)
   }
 
@@ -151,14 +153,13 @@ internal class DefaultAndroidHapticExecutor(context: Context) : HapticExecutor {
 }
 
 internal class AndroidHapticHandle(private var vibrator: Vibrator?) : HapticHandle {
-
-  override var isActive: Boolean = vibrator != null
-    private set
+  private val _isActive = AtomicBoolean(vibrator != null)
+  override val isActive: Boolean
+    get() = _isActive.get()
 
   @RequiresPermission(Manifest.permission.VIBRATE)
   override fun cancel() {
-    if (!isActive) return
-    isActive = false
+    if (!_isActive.compareAndSet(true, false)) return
     vibrator?.cancel()
     vibrator = null
   }


### PR DESCRIPTION
  ## Issue

  <!-- No specific issue, proactive thread-safety improvement -->

  ## Summary

  Fix memory visibility issue in `AndroidHapticHandle` by using `AtomicBoolean` for thread-safe state management.

  ### Problem
  `isActive` was a plain `var` without volatile semantics, causing potential memory visibility issues when `cancel()` is called from multiple threads:

  ```kotlin
  // Before
  override var isActive = vibrator != null
      private set

  override fun cancel() {
      if (!isActive) return  // Could read stale value
      isActive = false
      vibrator?.cancel()
  }
```

  In Compose environments, concurrent calls can occur from lifecycle callbacks and coroutines simultaneously.

  Solution

  Use AtomicBoolean to guarantee memory visibility and atomic state transitions:

```kotlin
  // After
  private val _isActive = AtomicBoolean(vibrator != null)
  override val isActive: Boolean
      get() = _isActive.get()

  override fun cancel() {
      if (!_isActive.compareAndSet(true, false)) return
      vibrator?.cancel()
  }
```

  Implementation Highlights

  - AtomicBoolean ensures memory visibility across threads
  - compareAndSet provides atomic check-and-update
  - Getter pattern maintains interface compatibility

  Additional Context

  While the practical impact is minimal (vibrator.cancel() is idempotent), this ensures correct multi-threaded behavior per JMM specification. As library code, we should handle edge cases that application code might reasonably trigger, even if rare.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of haptic feedback cancellation on Android devices through enhanced thread-safe state management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->