### PR TITLE
build: integrate Kover test coverage tool at `jindong-core`

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,7 +78,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: mi-kas/kover-report@v1
       with:
-        path: ${{ github.workspace }}/jindong/build/reports/kover/xml/report.xml
+        path: ${{ github.workspace }}/jindong/build/reports/kover/report.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         title: Test Coverage Report
         update-comment: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -78,7 +78,7 @@ jobs:
       if: github.event_name == 'pull_request'
       uses: mi-kas/kover-report@v1
       with:
-        path: ${{ github.workspace }}/jindong/build/reports/kover/report.xml
+        path: ${{ github.workspace }}/jindong/build/reports/kover/xml/report.xml
         token: ${{ secrets.GITHUB_TOKEN }}
         title: Test Coverage Report
         update-comment: true

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -15,6 +15,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: write
 
 jobs:
   check:
@@ -59,3 +60,27 @@ jobs:
       uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
       with:
         arguments: allTests
+    - name: Generate Kover Coverage Report
+      uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
+      with:
+        arguments: koverXmlReport
+    - name: Generate Kover HTML Report
+      uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
+      with:
+        arguments: koverHtmlReport
+    - name: Upload Coverage Report
+      uses: actions/upload-artifact@v4
+      with:
+        name: coverage-report
+        path: jindong/build/reports/kover/html
+    - name: Add coverage report to PR
+      id: kover
+      if: github.event_name == 'pull_request'
+      uses: mi-kas/kover-report@v1
+      with:
+        path: ${{ github.workspace }}/jindong/build/reports/kover/report.xml
+        token: ${{ secrets.GITHUB_TOKEN }}
+        title: Test Coverage Report
+        update-comment: true
+        min-coverage-overall: 0
+        min-coverage-changed-files: 0

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -63,24 +63,24 @@ jobs:
     - name: Generate Kover Coverage Report
       uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
       with:
-        arguments: koverXmlReport
+        arguments: :jindong-core:koverXmlReport
     - name: Generate Kover HTML Report
       uses: gradle/gradle-build-action@ce999babab2de1c4b649dc15f0ee67e6246c994f
       with:
-        arguments: koverHtmlReport
+        arguments: :jindong-core:koverHtmlReport
     - name: Upload Coverage Report
       uses: actions/upload-artifact@v4
       with:
         name: coverage-report
-        path: jindong/build/reports/kover/html
+        path: jindong-core/build/reports/kover/html
     - name: Add coverage report to PR
       id: kover
       if: github.event_name == 'pull_request'
       uses: mi-kas/kover-report@v1
       with:
-        path: ${{ github.workspace }}/jindong/build/reports/kover/report.xml
+        path: ${{ github.workspace }}/jindong-core/build/reports/kover/report.xml
         token: ${{ secrets.GITHUB_TOKEN }}
-        title: Test Coverage Report
+        title: Jindong Core Test Coverage Report
         update-comment: true
         min-coverage-overall: 0
         min-coverage-changed-files: 0

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -6,6 +6,7 @@ plugins {
     alias(libs.plugins.vanniktech.mavenPublish) apply false
     alias(libs.plugins.spotless) apply false
     alias(libs.plugins.binaryCompatibilityValidator) apply false
+    alias(libs.plugins.kover) apply false
 }
 
 subprojects {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -25,6 +25,7 @@ kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-c
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }
 kotest-assertions-core = { module = "io.kotest:kotest-assertions-core", version.ref = "kotest" }
+kotest-runner-junit5 = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 androidx-test-core = { module = "androidx.test:core", version.ref = "androidxTest" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidxTest" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ robolectric = "4.16"
 androidxTest = "1.7.0"
 androidxActivity = "1.12.2"
 androidxAnnotation = "1.9.1"
+kover = "0.9.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -43,3 +44,4 @@ kotest = { id = "io.kotest", version.ref = "kotest" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 android-application = { id = "com.android.application", version.ref = "agp" }
 composeMultiplatform = { id = "org.jetbrains.compose", version.ref = "composeMultiplatform" }
+kover = { id = "org.jetbrains.kotlinx.kover", version.ref = "kover" }

--- a/jindong-compose/build.gradle.kts
+++ b/jindong-compose/build.gradle.kts
@@ -23,7 +23,6 @@ plugins {
     alias(libs.plugins.kotest)
     alias(libs.plugins.ksp)
     alias(libs.plugins.binaryCompatibilityValidator)
-    alias(libs.plugins.kover)
 }
 
 apiValidation {
@@ -117,19 +116,6 @@ mavenPublishing {
             url = "https://github.com/compose-jindong/jindong"
             connection = "scm:git:git://github.com/compose-jindong/jindong.git"
             developerConnection = "scm:git:ssh://github.com/compose-jindong/jindong.git"
-        }
-    }
-}
-
-kover {
-    reports {
-        total {
-            html {
-                onCheck = true
-            }
-            xml {
-                onCheck = true
-            }
         }
     }
 }

--- a/jindong-compose/build.gradle.kts
+++ b/jindong-compose/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.kotest)
     alias(libs.plugins.ksp)
     alias(libs.plugins.binaryCompatibilityValidator)
+    alias(libs.plugins.kover)
 }
 
 apiValidation {
@@ -116,6 +117,19 @@ mavenPublishing {
             url = "https://github.com/compose-jindong/jindong"
             connection = "scm:git:git://github.com/compose-jindong/jindong.git"
             developerConnection = "scm:git:ssh://github.com/compose-jindong/jindong.git"
+        }
+    }
+}
+
+kover {
+    reports {
+        total {
+            html {
+                onCheck = true
+            }
+            xml {
+                onCheck = true
+            }
         }
     }
 }

--- a/jindong-core/build.gradle.kts
+++ b/jindong-core/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
   alias(libs.plugins.kotest)
   alias(libs.plugins.ksp)
   alias(libs.plugins.binaryCompatibilityValidator)
+  alias(libs.plugins.kover)
 }
 
 apiValidation {
@@ -100,6 +101,19 @@ mavenPublishing {
       url = "https://github.com/compose-jindong/jindong"
       connection = "scm:git:git://github.com/compose-jindong/jindong.git"
       developerConnection = "scm:git:ssh://github.com/compose-jindong/jindong.git"
+    }
+  }
+}
+
+kover {
+  reports {
+    total {
+      html {
+        onCheck = true
+      }
+      xml {
+        onCheck = true
+      }
     }
   }
 }

--- a/jindong-core/build.gradle.kts
+++ b/jindong-core/build.gradle.kts
@@ -48,6 +48,10 @@ kotlin {
         }
       }
     }
+
+    withHostTest {
+      isIncludeAndroidResources = true
+    }
   }
   iosX64()
   iosArm64()
@@ -66,6 +70,15 @@ kotlin {
       implementation(libs.kotest.framework.engine)
       implementation(libs.kotest.assertions.core)
     }
+
+    named("androidHostTest").dependencies {
+        implementation(libs.robolectric)
+        implementation(libs.androidx.test.core)
+        implementation(libs.androidx.test.runner)
+        implementation(libs.kotest.assertions.core)
+        implementation(libs.kotlinx.coroutines.test)
+        implementation(libs.kotest.runner.junit5)
+      }
   }
 }
 

--- a/jindong-core/build.gradle.kts
+++ b/jindong-core/build.gradle.kts
@@ -105,6 +105,10 @@ mavenPublishing {
   }
 }
 
+tasks.withType<Test>().configureEach {
+  useJUnitPlatform()
+}
+
 kover {
   reports {
     total {

--- a/jindong-core/src/androidHostTest/README.md
+++ b/jindong-core/src/androidHostTest/README.md
@@ -1,0 +1,36 @@
+# Android Host Tests
+
+Robolectric-based Android tests that run on JVM without requiring an emulator.
+
+## Running Tests
+
+```bash
+# Run Android host tests only
+./gradlew :jindong-compose:testAndroidHostTest
+
+# Run all tests (including commonTest, iosTest, etc.)
+./gradlew :jindong-compose:allTests
+```
+
+> **Note**: Use `--rerun-tasks` when you need to re-run tests that Gradle considers up-to-date (e.g., after changing test configuration or debugging flaky tests).
+
+## Test Scenarios
+
+To be updated...
+
+| Category | Test | Jindong Mapping |
+|----------|------|-----------------|
+| **OneShot** | High intensity (255) | `HapticIntensity.HIGH` |
+| | Medium intensity (128) | `HapticIntensity.MEDIUM` |
+| | Low intensity (64) | `HapticIntensity.LIGHT` |
+| **Waveform** | Simple sequence | `Sequence { Haptic, Delay, Haptic }` |
+| | Complex sequence | `Repeat { Haptic, Delay }` |
+| **Edge Cases** | Minimum duration (1ms) | - |
+| | Minimum amplitude (1) | - |
+| **Control** | Cancel | `executor.cancel()` |
+
+
+## Configuration
+
+- **SDK**: API 26 (Android 8.0)
+- **Runner**: `RobolectricTestRunner`

--- a/jindong-core/src/androidHostTest/README.md
+++ b/jindong-core/src/androidHostTest/README.md
@@ -6,10 +6,10 @@ Robolectric-based Android tests that run on JVM without requiring an emulator.
 
 ```bash
 # Run Android host tests only
-./gradlew :jindong-compose:testAndroidHostTest
+./gradlew :jindong-core:testAndroidHostTest
 
 # Run all tests (including commonTest, iosTest, etc.)
-./gradlew :jindong-compose:allTests
+./gradlew :jindong-core:allTests
 ```
 
 > **Note**: Use `--rerun-tasks` when you need to re-run tests that Gradle considers up-to-date (e.g., after changing test configuration or debugging flaky tests).

--- a/jindong-core/src/androidHostTest/kotlin/io/github/jindong/android/AndroidVibratorTest.kt
+++ b/jindong-core/src/androidHostTest/kotlin/io/github/jindong/android/AndroidVibratorTest.kt
@@ -1,0 +1,342 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.jindong.android
+
+import android.content.Context
+import android.os.Build
+import android.os.Vibrator
+import androidx.test.core.app.ApplicationProvider
+import io.github.compose.jindong.core.executor.HapticExecutor
+import io.github.compose.jindong.core.executor.createHapticExecutor
+import io.github.compose.jindong.core.model.HapticIntensity
+import io.github.compose.jindong.core.model.HapticPattern
+import io.github.compose.jindong.core.model.ScheduledHapticEvent
+import io.kotest.assertions.throwables.shouldNotThrow
+import io.kotest.matchers.shouldBe
+import kotlinx.coroutines.test.runTest
+import org.junit.Before
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import org.robolectric.Shadows.shadowOf
+import org.robolectric.annotation.Config
+import org.robolectric.shadows.ShadowVibrator
+
+/**
+ * Tests for Jindong's AndroidHapticExecutor using Robolectric.
+ *
+ * Verify that Jindong's AndroidHapticExecutor correctly translates
+ * haptic patterns into Android VibrationEffect API calls.
+ *
+ * - Single event patterns: single vibrations with various intensity levels
+ * - Sequence patterns: complex sequences with delays and multiple intensities
+ * - Edge cases: minimum duration, minimum amplitude, cancellation
+ */
+@RunWith(RobolectricTestRunner::class)
+@Config(sdk = [Build.VERSION_CODES.O])
+class AndroidVibratorTest {
+
+  private lateinit var shadowVibrator: ShadowVibrator
+  private lateinit var executor: HapticExecutor
+
+  @Before
+  fun setup() {
+    val context: Context = ApplicationProvider.getApplicationContext()
+    val vibrator = context.getSystemService(Vibrator::class.java)
+    shadowVibrator = shadowOf(vibrator).also { it.setHasAmplitudeControl(true) }
+    executor = createHapticExecutor(context)
+  }
+
+  @Test
+  fun `executor should be supported`() {
+    executor.isSupported shouldBe true
+  }
+
+  // ============================================================================
+  // Single Event Pattern Tests (HapticIntensity levels)
+  // ============================================================================
+
+  @Test
+  fun `should vibrate with HIGH intensity`() = runTest {
+    // HapticIntensity.HIGH (value = 1.0 -> 255)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.HIGH,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    // Single event split: [100ms event] + [1ms gap] + [1ms post] + [1ms end]
+    shadowVibrator.pattern shouldBe longArrayOf(100, 1, 1, 1)
+  }
+
+  @Test
+  fun `should vibrate with MEDIUM intensity`() = runTest {
+    // HapticIntensity.MEDIUM (value = 0.5 -> 127)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 200,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    shadowVibrator.pattern shouldBe longArrayOf(200, 1, 1, 1)
+  }
+
+  @Test
+  fun `should vibrate with LIGHT intensity`() = runTest {
+    // HapticIntensity.LIGHT (value = 0.25 -> 63)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 150,
+          intensity = HapticIntensity.LIGHT,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    shadowVibrator.pattern shouldBe longArrayOf(150, 1, 1, 1)
+  }
+
+  @Test
+  fun `should vibrate with STRONG intensity`() = runTest {
+    // HapticIntensity.STRONG (value = 0.75 -> 191)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.STRONG,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    shadowVibrator.pattern shouldBe longArrayOf(100, 1, 1, 1)
+  }
+
+  @Test
+  fun `should vibrate with Custom intensity`() = runTest {
+    // HapticIntensity.Custom(0.65f) -> 165
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.Custom(0.65f),
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    shadowVibrator.pattern shouldBe longArrayOf(100, 1, 1, 1)
+  }
+
+  // ============================================================================
+  // Sequence Pattern Tests (Multiple events with delays)
+  // ============================================================================
+
+  @Test
+  fun `should handle sequence pattern with delays`() = runTest {
+    // Pattern: vibrate(100ms@HIGH) -> pause(50ms) -> vibrate(100ms@MEDIUM)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.HIGH,
+        ),
+        ScheduledHapticEvent(
+          startTimeMs = 150, // 100ms + 50ms delay
+          durationMs = 100,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    // [100ms event1] + [50ms gap] + [100ms event2] + [1ms end]
+    shadowVibrator.pattern shouldBe longArrayOf(100, 50, 100, 1)
+  }
+
+  @Test
+  fun `should handle complex sequence with multiple segments`() = runTest {
+    // Pattern: Haptic -> Delay -> Haptic -> Delay -> Haptic
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.HIGH,
+        ),
+        ScheduledHapticEvent(
+          startTimeMs = 150, // 100ms + 50ms delay
+          durationMs = 100,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+        ScheduledHapticEvent(
+          startTimeMs = 300, // 250ms + 50ms delay
+          durationMs = 100,
+          intensity = HapticIntensity.HIGH,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    // [100ms event1] + [50ms gap1] + [100ms event2] + [50ms gap2] + [100ms event3] + [1ms end]
+    shadowVibrator.pattern shouldBe longArrayOf(100, 50, 100, 50, 100, 1)
+  }
+
+  @Test
+  fun `should handle back-to-back events without gaps`() = runTest {
+    // Pattern: Three consecutive haptics (like Triple Tap)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 25,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+        ScheduledHapticEvent(
+          startTimeMs = 25,
+          durationMs = 25,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+        ScheduledHapticEvent(
+          startTimeMs = 50,
+          durationMs = 25,
+          intensity = HapticIntensity.MEDIUM,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    // Back-to-back events without gaps in input: [25ms event1] + [25ms event2] + [25ms event3] + [1ms end]
+    shadowVibrator.pattern shouldBe longArrayOf(25, 25, 25, 1)
+  }
+
+  // ============================================================================
+  // Edge Cases
+  // ============================================================================
+
+  @Test
+  fun `should handle minimum duration (1ms)`() = runTest {
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 1,
+          intensity = HapticIntensity.HIGH,
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    // Single event split: [1ms event] + [1ms gap] + [1ms post] + [1ms end]
+    shadowVibrator.pattern shouldBe longArrayOf(1, 1, 1, 1)
+  }
+
+  @Test
+  fun `should handle minimum intensity`() = runTest {
+    // Custom(0.0) should map to amplitude 1 (not 0, as 0 means off)
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 100,
+          intensity = HapticIntensity.Custom(0.0f),
+        ),
+      ),
+    )
+
+    executor.execute(pattern)
+
+    shadowVibrator.isVibrating shouldBe true
+    shadowVibrator.pattern shouldBe longArrayOf(100, 1, 1, 1)
+  }
+
+  @Test
+  fun `should handle empty pattern gracefully`() = runTest {
+    val pattern = HapticPattern.Empty
+
+    executor.execute(pattern)
+
+    // Should not crash, but also should not vibrate
+    shadowVibrator.isVibrating shouldBe false
+  }
+
+  // ============================================================================
+  // Control Operations
+  // ============================================================================
+
+  @Test
+  fun `should cancel vibration via HapticHandle`() = runTest {
+    val pattern = HapticPattern(
+      listOf(
+        ScheduledHapticEvent(
+          startTimeMs = 0,
+          durationMs = 1000,
+          intensity = HapticIntensity.HIGH,
+        ),
+      ),
+    )
+
+    // Start vibration and get handle
+    val handle = executor.executeAsync(pattern)
+    shadowVibrator.isVibrating shouldBe true
+    handle.isActive shouldBe true
+
+    // Cancel via handle
+    handle.cancel()
+    shadowVibrator.isVibrating shouldBe false
+    handle.isActive shouldBe false
+  }
+
+  @Test
+  fun `should release executor resources`() {
+    shouldNotThrow<Exception> {
+      executor.release()
+    }
+  }
+}


### PR DESCRIPTION
## Issue

<!-- Link the related issue(s) -->
close #62 

## Summary
<!-- Briefly describe what this PR does -->
Integrate [Kotlin/kotlinx-kover](https://github.com/Kotlin/kotlinx-kover) to get a test coverage report.
(Kover is an official Kotlin test coverage tool)

### Implementation Highlights (Optional)
<!-- Explain key technical decisions, patterns, or algorithms -->
<!-- What should reviewers pay attention to? -->
This PR currently focuses on reporting capabilities. Enforcing verification rules (e.g., failing the build if coverage drops below a certain %) can be added in a future PR(or not).

<!-- Test Results are handled by CI-->
<!-- ## Test Results -->

## Additional Context (Optional)
<!-- Any other context, design decisions, or references -->

You can generate the coverage report locally by running:
```
./gradlew koverHtmlReport
```
The report will be available at `build/reports/kover/html/index.html`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI now generates and uploads code coverage reports (HTML & XML) and posts an automated coverage summary to pull requests; build config updated to include coverage tooling and versions.

* **Tests**
  * Added comprehensive Android host tests validating haptic/vibrator behavior, sequencing, edge cases, cancellation, and resource cleanup.

* **Documentation**
  * Added README with instructions for running the Android host tests.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->