### PR TITLE
feat: add platform-specific haptic properties (#57)

### DIFF
--- a/jindong-compose/api/jindong-compose.api
+++ b/jindong-compose/api/jindong-compose.api
@@ -22,7 +22,7 @@ public final class io/github/compose/jindong/dsl/DelayKt {
 }
 
 public final class io/github/compose/jindong/dsl/HapticKt {
-	public static final fun Haptic-NcHsxvU (Lio/github/compose/jindong/JindongScope;JLio/github/compose/jindong/model/HapticIntensity;Landroidx/compose/runtime/Composer;II)V
+	public static final fun Haptic-nRVORKE (Lio/github/compose/jindong/JindongScope;JLio/github/compose/jindong/model/HapticIntensity;Lio/github/compose/jindong/model/HapticProperties;Landroidx/compose/runtime/Composer;II)V
 }
 
 public final class io/github/compose/jindong/dsl/RepeatKt {
@@ -83,5 +83,31 @@ public final class io/github/compose/jindong/model/HapticIntensity$STRONG : io/g
 	public fun equals (Ljava/lang/Object;)Z
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/compose/jindong/model/HapticProperties {
+	public static final field $stable I
+	public static final field Companion Lio/github/compose/jindong/model/HapticProperties$Companion;
+	public synthetic fun <init> (Ljava/lang/Float;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;ILkotlin/jvm/internal/DefaultConstructorMarker;)V
+	public final fun component1 ()Ljava/lang/Float;
+	public final fun component2-FghU774 ()Lkotlin/time/Duration;
+	public final fun component3-FghU774 ()Lkotlin/time/Duration;
+	public final fun component4-FghU774 ()Lkotlin/time/Duration;
+	public final fun envelope-NIICwX4 (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;)Lio/github/compose/jindong/model/HapticProperties;
+	public static synthetic fun envelope-NIICwX4$default (Lio/github/compose/jindong/model/HapticProperties;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;ILjava/lang/Object;)Lio/github/compose/jindong/model/HapticProperties;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getAttackTime-FghU774 ()Lkotlin/time/Duration;
+	public final fun getDecayTime-FghU774 ()Lkotlin/time/Duration;
+	public final fun getReleaseTime-FghU774 ()Lkotlin/time/Duration;
+	public final fun getSharpness ()Ljava/lang/Float;
+	public fun hashCode ()I
+	public final fun sharpness (F)Lio/github/compose/jindong/model/HapticProperties;
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class io/github/compose/jindong/model/HapticProperties$Companion {
+	public final fun envelope-NIICwX4 (Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;)Lio/github/compose/jindong/model/HapticProperties;
+	public static synthetic fun envelope-NIICwX4$default (Lio/github/compose/jindong/model/HapticProperties$Companion;Lkotlin/time/Duration;Lkotlin/time/Duration;Lkotlin/time/Duration;ILjava/lang/Object;)Lio/github/compose/jindong/model/HapticProperties;
+	public final fun sharpness (F)Lio/github/compose/jindong/model/HapticProperties;
 }
 

--- a/jindong-compose/api/jindong-compose.klib.api
+++ b/jindong-compose/api/jindong-compose.klib.api
@@ -12,6 +12,32 @@ open annotation class io.github.compose.jindong/JindongScopeMarker : kotlin/Anno
 
 abstract interface io.github.compose.jindong/JindongScope // io.github.compose.jindong/JindongScope|null[0]
 
+final class io.github.compose.jindong.model/HapticProperties { // io.github.compose.jindong.model/HapticProperties|null[0]
+    final val attackTime // io.github.compose.jindong.model/HapticProperties.attackTime|{}attackTime[0]
+        final fun <get-attackTime>(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.attackTime.<get-attackTime>|<get-attackTime>(){}[0]
+    final val decayTime // io.github.compose.jindong.model/HapticProperties.decayTime|{}decayTime[0]
+        final fun <get-decayTime>(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.decayTime.<get-decayTime>|<get-decayTime>(){}[0]
+    final val releaseTime // io.github.compose.jindong.model/HapticProperties.releaseTime|{}releaseTime[0]
+        final fun <get-releaseTime>(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.releaseTime.<get-releaseTime>|<get-releaseTime>(){}[0]
+    final val sharpness // io.github.compose.jindong.model/HapticProperties.sharpness|{}sharpness[0]
+        final fun <get-sharpness>(): kotlin/Float? // io.github.compose.jindong.model/HapticProperties.sharpness.<get-sharpness>|<get-sharpness>(){}[0]
+
+    final fun component1(): kotlin/Float? // io.github.compose.jindong.model/HapticProperties.component1|component1(){}[0]
+    final fun component2(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.component2|component2(){}[0]
+    final fun component3(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.component3|component3(){}[0]
+    final fun component4(): kotlin.time/Duration? // io.github.compose.jindong.model/HapticProperties.component4|component4(){}[0]
+    final fun envelope(kotlin.time/Duration? = ..., kotlin.time/Duration? = ..., kotlin.time/Duration? = ...): io.github.compose.jindong.model/HapticProperties // io.github.compose.jindong.model/HapticProperties.envelope|envelope(kotlin.time.Duration?;kotlin.time.Duration?;kotlin.time.Duration?){}[0]
+    final fun equals(kotlin/Any?): kotlin/Boolean // io.github.compose.jindong.model/HapticProperties.equals|equals(kotlin.Any?){}[0]
+    final fun hashCode(): kotlin/Int // io.github.compose.jindong.model/HapticProperties.hashCode|hashCode(){}[0]
+    final fun sharpness(kotlin/Float): io.github.compose.jindong.model/HapticProperties // io.github.compose.jindong.model/HapticProperties.sharpness|sharpness(kotlin.Float){}[0]
+    final fun toString(): kotlin/String // io.github.compose.jindong.model/HapticProperties.toString|toString(){}[0]
+
+    final object Companion { // io.github.compose.jindong.model/HapticProperties.Companion|null[0]
+        final fun envelope(kotlin.time/Duration? = ..., kotlin.time/Duration? = ..., kotlin.time/Duration? = ...): io.github.compose.jindong.model/HapticProperties // io.github.compose.jindong.model/HapticProperties.Companion.envelope|envelope(kotlin.time.Duration?;kotlin.time.Duration?;kotlin.time.Duration?){}[0]
+        final fun sharpness(kotlin/Float): io.github.compose.jindong.model/HapticProperties // io.github.compose.jindong.model/HapticProperties.Companion.sharpness|sharpness(kotlin.Float){}[0]
+    }
+}
+
 sealed class io.github.compose.jindong.model/HapticIntensity { // io.github.compose.jindong.model/HapticIntensity|null[0]
     final val value // io.github.compose.jindong.model/HapticIntensity.value|{}value[0]
         final fun <get-value>(): kotlin/Float // io.github.compose.jindong.model/HapticIntensity.value.<get-value>|<get-value>(){}[0]
@@ -56,13 +82,14 @@ final val io.github.compose.jindong.model/io_github_compose_jindong_model_Haptic
 final val io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop|#static{}io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop[0]
 final val io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop|#static{}io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop[0]
 final val io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop|#static{}io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop[0]
+final val io.github.compose.jindong.model/io_github_compose_jindong_model_HapticProperties$stableprop // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticProperties$stableprop|#static{}io_github_compose_jindong_model_HapticProperties$stableprop[0]
 final val io.github.compose.jindong/ms // io.github.compose.jindong/ms|@kotlin.Int{}ms[0]
     final fun (kotlin/Int).<get-ms>(): kotlin.time/Duration // io.github.compose.jindong/ms.<get-ms>|<get-ms>@kotlin.Int(){}[0]
 final val io.github.compose.jindong/ms // io.github.compose.jindong/ms|@kotlin.Long{}ms[0]
     final fun (kotlin/Long).<get-ms>(): kotlin.time/Duration // io.github.compose.jindong/ms.<get-ms>|<get-ms>@kotlin.Long(){}[0]
 
 final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/Delay(kotlin.time/Duration, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong.dsl/Delay|Delay@io.github.compose.jindong.JindongScope(kotlin.time.Duration;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
-final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/Haptic(kotlin.time/Duration, io.github.compose.jindong.model/HapticIntensity?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // io.github.compose.jindong.dsl/Haptic|Haptic@io.github.compose.jindong.JindongScope(kotlin.time.Duration;io.github.compose.jindong.model.HapticIntensity?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
+final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/Haptic(kotlin.time/Duration, io.github.compose.jindong.model/HapticIntensity?, io.github.compose.jindong.model/HapticProperties?, androidx.compose.runtime/Composer?, kotlin/Int, kotlin/Int) // io.github.compose.jindong.dsl/Haptic|Haptic@io.github.compose.jindong.JindongScope(kotlin.time.Duration;io.github.compose.jindong.model.HapticIntensity?;io.github.compose.jindong.model.HapticProperties?;androidx.compose.runtime.Composer?;kotlin.Int;kotlin.Int){}[0]
 final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/Repeat(kotlin/Int, kotlin/Function3<io.github.compose.jindong/JindongScope, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong.dsl/Repeat|Repeat@io.github.compose.jindong.JindongScope(kotlin.Int;kotlin.Function3<io.github.compose.jindong.JindongScope,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
 final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/RepeatWithIndex(kotlin/Int, kotlin/Function4<io.github.compose.jindong/JindongScope, kotlin/Int, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong.dsl/RepeatWithIndex|RepeatWithIndex@io.github.compose.jindong.JindongScope(kotlin.Int;kotlin.Function4<io.github.compose.jindong.JindongScope,kotlin.Int,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
 final fun (io.github.compose.jindong/JindongScope).io.github.compose.jindong.dsl/Sequence(kotlin/Function3<io.github.compose.jindong/JindongScope, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong.dsl/Sequence|Sequence@io.github.compose.jindong.JindongScope(kotlin.Function3<io.github.compose.jindong.JindongScope,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
@@ -72,5 +99,6 @@ final fun io.github.compose.jindong.model/io_github_compose_jindong_model_Haptic
 final fun io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop_getter(): kotlin/Int // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop_getter|io_github_compose_jindong_model_HapticIntensity_LIGHT$stableprop_getter(){}[0]
 final fun io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop_getter(): kotlin/Int // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop_getter|io_github_compose_jindong_model_HapticIntensity_MEDIUM$stableprop_getter(){}[0]
 final fun io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop_getter(): kotlin/Int // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop_getter|io_github_compose_jindong_model_HapticIntensity_STRONG$stableprop_getter(){}[0]
+final fun io.github.compose.jindong.model/io_github_compose_jindong_model_HapticProperties$stableprop_getter(): kotlin/Int // io.github.compose.jindong.model/io_github_compose_jindong_model_HapticProperties$stableprop_getter|io_github_compose_jindong_model_HapticProperties$stableprop_getter(){}[0]
 final fun io.github.compose.jindong/Jindong(kotlin/Array<out kotlin/Any?>..., kotlin/Function3<io.github.compose.jindong/JindongScope, androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong/Jindong|Jindong(kotlin.Array<out|kotlin.Any?>...;kotlin.Function3<io.github.compose.jindong.JindongScope,androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]
 final fun io.github.compose.jindong/JindongProvider(kotlin/Function2<androidx.compose.runtime/Composer, kotlin/Int, kotlin/Unit>, androidx.compose.runtime/Composer?, kotlin/Int) // io.github.compose.jindong/JindongProvider|JindongProvider(kotlin.Function2<androidx.compose.runtime.Composer,kotlin.Int,kotlin.Unit>;androidx.compose.runtime.Composer?;kotlin.Int){}[0]

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/dsl/Haptic.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/dsl/Haptic.kt
@@ -20,6 +20,8 @@ import androidx.compose.runtime.ComposeNode
 import io.github.compose.jindong.JindongScope
 import io.github.compose.jindong.compose.JindongApplier
 import io.github.compose.jindong.model.HapticIntensity
+import io.github.compose.jindong.model.HapticProperties
+import io.github.compose.jindong.model.toIosHapticParameters
 import io.github.compose.jindong.node.HapticEventNode
 import kotlin.time.Duration
 
@@ -35,14 +37,22 @@ import kotlin.time.Duration
  *
  * @param duration How long the vibration lasts
  * @param intensity Vibration strength (default: [HapticIntensity.MEDIUM])
+ * @param properties iOS Core Haptics properties (ignored on Android)
  */
 @Composable
 fun JindongScope.Haptic(
   duration: Duration,
   intensity: HapticIntensity = HapticIntensity.MEDIUM,
+  properties: HapticProperties? = null,
 ) {
   ComposeNode<HapticEventNode, JindongApplier>(
-    factory = { HapticEventNode(duration.inWholeMilliseconds, intensity) },
+    factory = {
+      HapticEventNode(
+        durationMs = duration.inWholeMilliseconds,
+        intensity = intensity,
+        iosParameters = properties?.toIosHapticParameters(),
+      )
+    },
     update = { },
   )
 }

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/model/HapticProperties.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/model/HapticProperties.kt
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.compose.jindong.model
+
+import kotlin.time.Duration
+
+/**
+ * iOS Core Haptics properties. Ignored on Android.
+ */
+@ConsistentCopyVisibility
+data class HapticProperties internal constructor(
+  val sharpness: Float? = null,
+  val attackTime: Duration? = null,
+  val decayTime: Duration? = null,
+  val releaseTime: Duration? = null,
+) {
+  init {
+    attackTime?.let {
+      require(!it.isNegative()) { "attackTime must be non-negative" }
+    }
+    decayTime?.let {
+      require(!it.isNegative()) { "decayTime must be non-negative" }
+    }
+    releaseTime?.let {
+      require(!it.isNegative()) { "releaseTime must be non-negative" }
+    }
+  }
+
+  fun sharpness(value: Float): HapticProperties = copy(sharpness = value)
+
+  fun envelope(
+    attack: Duration? = null,
+    decay: Duration? = null,
+    release: Duration? = null,
+  ): HapticProperties = copy(
+    attackTime = attack ?: attackTime,
+    decayTime = decay ?: decayTime,
+    releaseTime = release ?: releaseTime,
+  )
+
+  companion object {
+    fun sharpness(value: Float): HapticProperties = HapticProperties(sharpness = value)
+
+    fun envelope(
+      attack: Duration? = null,
+      decay: Duration? = null,
+      release: Duration? = null,
+    ): HapticProperties = HapticProperties(
+      attackTime = attack,
+      decayTime = decay,
+      releaseTime = release,
+    )
+  }
+}
+
+internal fun HapticProperties.toIosHapticParameters(): IosHapticParameters = IosHapticParameters(
+  sharpness = sharpness ?: 0.5f,
+  attackTime = attackTime,
+  decayTime = decayTime,
+  releaseTime = releaseTime,
+)

--- a/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/model/HapticPropertiesTest.kt
+++ b/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/model/HapticPropertiesTest.kt
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.compose.jindong.model
+
+import io.github.compose.jindong.ms
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+class HapticPropertiesTest :
+  FunSpec({
+    context("sharpness") {
+      test("creates properties with sharpness") {
+        val properties = HapticProperties.sharpness(0.9f)
+        properties.sharpness shouldBe 0.9f
+        properties.attackTime shouldBe null
+      }
+    }
+
+    context("envelope") {
+      test("creates properties with envelope") {
+        val properties = HapticProperties.envelope(
+          attack = 50.ms,
+          decay = 30.ms,
+          release = 20.ms,
+        )
+        properties.sharpness shouldBe null
+        properties.attackTime shouldBe 50.ms
+        properties.decayTime shouldBe 30.ms
+        properties.releaseTime shouldBe 20.ms
+      }
+
+      test("envelope should have non-negative times") {
+        shouldThrow<IllegalArgumentException> {
+          HapticProperties.envelope(attack = (-50).ms)
+        }
+      }
+    }
+
+    context("chaining") {
+      test("sharpness then envelope") {
+        val properties = HapticProperties
+          .sharpness(0.9f)
+          .envelope(attack = 50.ms)
+
+        properties.sharpness shouldBe 0.9f
+        properties.attackTime shouldBe 50.ms
+      }
+
+      test("envelope then sharpness") {
+        val properties = HapticProperties
+          .envelope(attack = 50.ms)
+          .sharpness(0.9f)
+
+        properties.sharpness shouldBe 0.9f
+        properties.attackTime shouldBe 50.ms
+      }
+    }
+
+    context("toIosHapticParameters") {
+      test("converts with defaults") {
+        val properties = HapticProperties.sharpness(0.8f)
+        val iosParams = properties.toIosHapticParameters()
+
+        iosParams.sharpness shouldBe 0.8f
+        iosParams.attackTime shouldBe null
+      }
+
+      test("uses default sharpness when null") {
+        val properties = HapticProperties.envelope(attack = 50.ms)
+        val iosParams = properties.toIosHapticParameters()
+
+        iosParams.sharpness shouldBe 0.5f
+        iosParams.attackTime shouldBe 50.ms
+      }
+    }
+  })

--- a/jindong-compose/src/iosMain/kotlin/io/github/compose/jindong/executor/HapticExecutor.ios.kt
+++ b/jindong-compose/src/iosMain/kotlin/io/github/compose/jindong/executor/HapticExecutor.ios.kt
@@ -28,8 +28,12 @@ import kotlinx.coroutines.delay
 import platform.CoreHaptics.CHHapticEngine
 import platform.CoreHaptics.CHHapticEvent
 import platform.CoreHaptics.CHHapticEventParameter
+import platform.CoreHaptics.CHHapticEventParameterIDAttackTime
+import platform.CoreHaptics.CHHapticEventParameterIDDecayTime
 import platform.CoreHaptics.CHHapticEventParameterIDHapticIntensity
 import platform.CoreHaptics.CHHapticEventParameterIDHapticSharpness
+import platform.CoreHaptics.CHHapticEventParameterIDReleaseTime
+import platform.CoreHaptics.CHHapticEventParameterIDSustained
 import platform.CoreHaptics.CHHapticEventTypeHapticContinuous
 import platform.CoreHaptics.CHHapticPattern
 import platform.Foundation.NSError
@@ -144,20 +148,62 @@ internal class DefaultIosHapticExecutor : HapticExecutor {
     val relativeTime = startTimeMs / 1000.0
     val duration = durationMs / 1000.0
 
-    val intensityEventParameter = CHHapticEventParameter(
-      parameterID = CHHapticEventParameterIDHapticIntensity,
-      value = intensity.value,
-    )
+    val hapticEventParameters = buildList {
+      add(
+        CHHapticEventParameter(
+          parameterID = CHHapticEventParameterIDHapticIntensity,
+          value = intensity.value,
+        ),
+      )
 
-    val sharpness = iosParameters?.sharpness ?: DEFAULT_SHARPNESS
-    val sharpnessEventParameter = CHHapticEventParameter(
-      parameterID = CHHapticEventParameterIDHapticSharpness,
-      value = sharpness,
-    )
+      val sharpness = iosParameters?.sharpness ?: DEFAULT_SHARPNESS
+      add(
+        CHHapticEventParameter(
+          parameterID = CHHapticEventParameterIDHapticSharpness,
+          value = sharpness,
+        ),
+      )
+
+      iosParameters?.attackTime?.let { attackTime ->
+        add(
+          CHHapticEventParameter(
+            parameterID = CHHapticEventParameterIDAttackTime,
+            value = attackTime.inWholeMilliseconds / 1000f,
+          ),
+        )
+      }
+
+      iosParameters?.decayTime?.let { decayTime ->
+        add(
+          CHHapticEventParameter(
+            parameterID = CHHapticEventParameterIDDecayTime,
+            value = decayTime.inWholeMilliseconds / 1000f,
+          ),
+        )
+      }
+
+      iosParameters?.releaseTime?.let { releaseTime ->
+        add(
+          CHHapticEventParameter(
+            parameterID = CHHapticEventParameterIDReleaseTime,
+            value = releaseTime.inWholeMilliseconds / 1000f,
+          ),
+        )
+      }
+
+      iosParameters?.sustained?.let { sustained ->
+        add(
+          CHHapticEventParameter(
+            parameterID = CHHapticEventParameterIDSustained,
+            value = if (sustained) 1f else 0f,
+          ),
+        )
+      }
+    }
 
     return CHHapticEvent(
       eventType = CHHapticEventTypeHapticContinuous,
-      parameters = listOf(intensityEventParameter, sharpnessEventParameter),
+      parameters = hapticEventParameters,
       relativeTime = relativeTime,
       duration = duration,
     )

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/SampleApp.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/SampleApp.kt
@@ -31,6 +31,7 @@ import io.github.compose.jindong.dsl.Haptic
 import io.github.compose.jindong.dsl.Repeat
 import io.github.compose.jindong.dsl.Sequence
 import io.github.compose.jindong.model.HapticIntensity
+import io.github.compose.jindong.model.HapticProperties
 import org.jetbrains.compose.resources.stringResource
 import kotlin.time.Duration.Companion.milliseconds
 
@@ -196,6 +197,26 @@ private fun HapticPatternEffect(patternType: HapticPatternType, trigger: Int) {
         Haptic(50.milliseconds, HapticIntensity.HIGH)
       }
     }
+
+    HapticPatternType.SHARP_TAP -> {
+      {
+        Haptic(
+          duration = 80.milliseconds,
+          properties = HapticProperties.sharpness(1.0f),
+        )
+      }
+    }
+
+    HapticPatternType.SOFT_ENVELOPE -> {
+      {
+        Haptic(
+          duration = 150.milliseconds,
+          properties = HapticProperties
+            .sharpness(0.3f)
+            .envelope(attack = 50.milliseconds, release = 40.milliseconds),
+        )
+      }
+    }
   }
 
   Jindong(trigger, content = pattern)
@@ -215,4 +236,6 @@ enum class HapticPatternType(
   SUCCESS("Success", "Success confirmation pattern"),
   ERROR("Error", "Error alert pattern"),
   RAMP_UP("Ramp Up", "Gradually increasing intensity"),
+  SHARP_TAP("Sharp Tap", "Sharp haptic (iOS)"),
+  SOFT_ENVELOPE("Soft Envelope", "Soft attack/release (iOS)"),
 }


### PR DESCRIPTION
## Issue

<!-- Link the related issue(s) -->
close #57

## Summary
<!-- Briefly describe what this PR does -->

Add `HapticProperties` API for iOS Core Haptics parameters (sharpness, ADSR envelope) with chainable builder pattern. Properties are automatically ignored on Android.

### Implementation Highlights (Optional)
<!-- Explain key technical decisions, patterns, or algorithms -->
<!-- What should reviewers pay attention to? -->

- `HapticProperties` uses internal constructor +  companion object entry points for chainable API       
(ex. `HapticProperties.sharpness(0.9f).envelope(attack =  50.ms)`)                                                 
- `toIosHapticParameters()` extension bridges public API to internal `IosHapticParameters`                        
- iOS executor applies envelope params (`attackTime`, `decayTime`, `releaseTime`) via `CHHapticEventParameter` 
- Android executor naturally ignores `iosParameters` — no fallback code needed 

## Additional Context (Optional)
<!-- Any other context, design decisions, or references -->
Added `SHARP_TAP` and `SOFT_ENVELOPE` patterns to the sample app for verification. Can remove if it's outside the scope of this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable haptic feedback parameters including sharpness and envelope timing (attack, decay, and release times) for enhanced tactile effect customization.
  * Introduced new haptic patterns: Sharp Tap and Soft Envelope, expanding available tactile feedback options.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->