### PR TITLE
fix: correct broken API Reference link in README and landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ For full documentation, visit [compose-jindong.github.io/jindong](https://compos
 - [Why Jindong](https://compose-jindong.github.io/jindong/docs/guide/why-jindong) - Motivation and benefits
 - [Getting Started](https://compose-jindong.github.io/jindong/docs/guide/getting-started) - Installation and setup
 - [Quick Start](https://compose-jindong.github.io/jindong/docs/guide/quick-start) - Build your first haptic pattern
-- [API Reference](https://compose-jindong.github.io/jindong/docs/api/core/jindong) - Complete API documentation
+- [API Reference](https://compose-jindong.github.io/jindong/docs/api/jindong-compose/jindong) - Complete API documentation
 
 ## License
 

--- a/documentation/components/home-page.tsx
+++ b/documentation/components/home-page.tsx
@@ -92,7 +92,7 @@ function Hero() {
             </Link>
             
             <Link
-              href="/docs/api/core/jindong"
+              href="/docs/api/jindong-compose/jindong"
                className="inline-flex h-12 items-center justify-center rounded-xl border border-zinc-200 bg-white px-8 font-medium text-zinc-900 transition-all hover:bg-zinc-50 dark:border-zinc-800 dark:bg-zinc-950 dark:text-zinc-100 dark:hover:bg-zinc-900"
             >
               API Reference


### PR DESCRIPTION
## Issue

<!-- Link the related issue(s) -->
close #82 

## Summary
<!-- Briefly describe what this PR does -->
Fix broken API Reference links in `README.md` and `documentation/components/home-page.tsx`.

Both links pointed to `/docs/api/core/jindong`, which returns a 404. The correct path is `/docs/api/jindong-compose/jindong`.

### Implementation Highlights (Optional)
<!-- Explain key technical decisions, patterns, or algorithms -->
<!-- What should reviewers pay attention to? -->
  - `README.md`: updated the API Reference URL
  - `documentation/components/home-page.tsx`: updated the `href` in the Hero section's API Reference button


<!-- Test Results are handled by CI-->
<!-- ## Test Results -->

## Additional Context (Optional)
<!-- Any other context, design decisions, or references -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated API Reference links to direct users to the correct API documentation resource.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/compose-jindong/jindong/pull/83)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->