### PR TITLE
fix(compose): recompile haptic pattern when Jindong keys change

### DIFF
--- a/documentation/content/docs/api/jindong-compose/composable-dsl/haptic.mdx
+++ b/documentation/content/docs/api/jindong-compose/composable-dsl/haptic.mdx
@@ -129,8 +129,8 @@ Jindong(trigger) {
 
 | Platform | Implementation |
 |----------|----------------|
-| Android | `VibrationEffect.createOneShot()` |
-| iOS | `CHHapticEvent` with `HapticTransient` or `HapticContinuous` |
+| Android | `VibrationEffect.createWaveform()` |
+| iOS | `CHHapticEvent` (`HapticContinuous`) played via `CHHapticEngine` |
 
 ## Notes
 

--- a/documentation/content/docs/api/jindong-compose/composable-dsl/repeat-with-index.mdx
+++ b/documentation/content/docs/api/jindong-compose/composable-dsl/repeat-with-index.mdx
@@ -167,7 +167,7 @@ RepeatWithIndex(5) { i -> Haptic((50 + i * 10).ms) }
 
 - Index is 0-based (0 to count-1)
 - Each iteration generates a separate node
-- `count` must be a positive value.
+- A `count` of 0 or less simply produces no output
 - The index can be used in any expression within the content block
 
 ## See Also

--- a/documentation/content/docs/api/jindong-compose/composable-dsl/repeat.mdx
+++ b/documentation/content/docs/api/jindong-compose/composable-dsl/repeat.mdx
@@ -166,7 +166,7 @@ RepeatWithIndex(5) { index ->
 ## Notes
 
 - `count` of 0 produces no output
-- If count is negative, it can cause app crash.
+- A negative `count` throws `IllegalArgumentException` (it must be non-negative)
 - Each iteration runs sequentially
 - Content block is evaluated `count` times at composition
 - All iterations have the same pattern

--- a/documentation/content/docs/guide/quick-start.mdx
+++ b/documentation/content/docs/guide/quick-start.mdx
@@ -253,6 +253,25 @@ Jindong(buttonClickCount) { ... }
 Jindong(System.currentTimeMillis()) { ... }
 ```
 
+### Reactive Patterns
+
+When a key changes, the content block is recompiled with the current state, so a
+value the block captures must also be one of the keys for the pattern to reflect it:
+
+```kotlin
+var level by remember { mutableStateOf(1) }
+
+// `level` is captured AND a key, so the pattern grows as `level` changes
+Jindong(level) {
+    RepeatWithIndex(level) { index ->
+        Haptic(50.ms, HapticIntensity.Custom(1f - index * 0.1f))
+    }
+}
+```
+
+If a captured value is not in the keys, the pattern keeps the value from the last
+key change instead of updating.
+
 ## Next Steps
 
 - [Jindong API](/docs/api/jindong-compose/jindong) - Deep dive into the main API

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ kover = "0.9.4"
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
 compose-runtime = { module = "org.jetbrains.compose.runtime:runtime", version.ref = "composeRuntime" }
+compose-ui-test = { module = "org.jetbrains.compose.ui:ui-test", version.ref = "composeMultiplatform" }
 kotlinx-coroutines-core = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-core", version.ref = "coroutines" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "coroutines" }
 kotest-framework-engine = { module = "io.kotest:kotest-framework-engine", version.ref = "kotest" }

--- a/jindong-compose/build.gradle.kts
+++ b/jindong-compose/build.gradle.kts
@@ -69,6 +69,8 @@ kotlin {
         commonTest.dependencies {
             implementation(libs.kotest.framework.engine)
             implementation(libs.kotest.assertions.core)
+            implementation(libs.compose.ui.test)
+            implementation(libs.kotlinx.coroutines.test)
         }
     }
 }

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/Jindong.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/Jindong.kt
@@ -56,7 +56,6 @@ fun Jindong(
   vararg keys: Any?,
   content: @Composable JindongScope.() -> Unit,
 ) {
-  // Thread keys so the pattern recompiles when state captured by content changes, not just once.
   val pattern = rememberHapticPattern(*keys) { content() }
   val executor = LocalHapticExecutor.current
 

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/Jindong.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/Jindong.kt
@@ -56,7 +56,8 @@ fun Jindong(
   vararg keys: Any?,
   content: @Composable JindongScope.() -> Unit,
 ) {
-  val pattern = rememberHapticPattern(content)
+  // Thread keys so the pattern recompiles when state captured by content changes, not just once.
+  val pattern = rememberHapticPattern(*keys) { content() }
   val executor = LocalHapticExecutor.current
 
   LaunchedEffect(*keys) {

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/RememberHapticPattern.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/RememberHapticPattern.kt
@@ -22,6 +22,10 @@ import io.github.compose.jindong.core.model.HapticPattern
 /**
  * Compiles and memoizes a haptic DSL pattern.
  *
+ * The pattern is recompiled whenever any of [keys] change, so a [content] block that captures
+ * mutable state stays in sync with that state instead of returning a stale first-compile result.
+ *
+ * @param keys Inputs that invalidate the memoized pattern when changed
  * @param content DSL block defining the haptic pattern
  * @return The compiled [HapticPattern]
  *
@@ -30,7 +34,8 @@ import io.github.compose.jindong.core.model.HapticPattern
  */
 @Composable
 internal fun rememberHapticPattern(
+  vararg keys: Any?,
   content: @Composable JindongScope.() -> Unit,
-): HapticPattern = remember {
+): HapticPattern = remember(*keys) {
   compilePattern(content)
 }

--- a/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/RememberHapticPattern.kt
+++ b/jindong-compose/src/commonMain/kotlin/io/github/compose/jindong/RememberHapticPattern.kt
@@ -22,9 +22,6 @@ import io.github.compose.jindong.core.model.HapticPattern
 /**
  * Compiles and memoizes a haptic DSL pattern.
  *
- * The pattern is recompiled whenever any of [keys] change, so a [content] block that captures
- * mutable state stays in sync with that state instead of returning a stale first-compile result.
- *
  * @param keys Inputs that invalidate the memoized pattern when changed
  * @param content DSL block defining the haptic pattern
  * @return The compiled [HapticPattern]

--- a/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/JindongReactiveTest.kt
+++ b/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/JindongReactiveTest.kt
@@ -22,37 +22,13 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.ui.test.ExperimentalTestApi
 import androidx.compose.ui.test.runComposeUiTest
-import io.github.compose.jindong.core.executor.HapticExecutor
-import io.github.compose.jindong.core.executor.HapticHandle
-import io.github.compose.jindong.core.model.HapticPattern
 import io.github.compose.jindong.core.ms
 import io.github.compose.jindong.dsl.Haptic
 import io.github.compose.jindong.dsl.RepeatWithIndex
 import io.github.compose.jindong.executor.LocalHapticExecutor
+import io.github.compose.jindong.executor.RecordingHapticExecutor
 import io.kotest.core.spec.style.FunSpec
 import io.kotest.matchers.shouldBe
-
-/**
- * Records executed patterns so a test can inspect what [Jindong] played for a given key.
- */
-private class RecordingHapticExecutor : HapticExecutor {
-  override val isSupported: Boolean = true
-
-  val executedPatterns = mutableListOf<HapticPattern>()
-
-  override suspend fun execute(pattern: HapticPattern) {
-    executedPatterns += pattern
-  }
-
-  override fun executeAsync(pattern: HapticPattern): HapticHandle = NoopHapticHandle
-
-  override fun release() = Unit
-
-  private object NoopHapticHandle : HapticHandle {
-    override val isActive: Boolean = false
-    override fun cancel() = Unit
-  }
-}
 
 class JindongReactiveTest :
   FunSpec({

--- a/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/JindongReactiveTest.kt
+++ b/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/JindongReactiveTest.kt
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+@file:OptIn(ExperimentalTestApi::class)
+
+package io.github.compose.jindong
+
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.test.ExperimentalTestApi
+import androidx.compose.ui.test.runComposeUiTest
+import io.github.compose.jindong.core.executor.HapticExecutor
+import io.github.compose.jindong.core.executor.HapticHandle
+import io.github.compose.jindong.core.model.HapticPattern
+import io.github.compose.jindong.core.ms
+import io.github.compose.jindong.dsl.Haptic
+import io.github.compose.jindong.dsl.RepeatWithIndex
+import io.github.compose.jindong.executor.LocalHapticExecutor
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+
+/**
+ * Records executed patterns so a test can inspect what [Jindong] played for a given key.
+ */
+private class RecordingHapticExecutor : HapticExecutor {
+  override val isSupported: Boolean = true
+
+  val executedPatterns = mutableListOf<HapticPattern>()
+
+  override suspend fun execute(pattern: HapticPattern) {
+    executedPatterns += pattern
+  }
+
+  override fun executeAsync(pattern: HapticPattern): HapticHandle = NoopHapticHandle
+
+  override fun release() = Unit
+
+  private object NoopHapticHandle : HapticHandle {
+    override val isActive: Boolean = false
+    override fun cancel() = Unit
+  }
+}
+
+class JindongReactiveTest :
+  FunSpec({
+    test("Jindong recompiles its pattern when the key changes") {
+      runComposeUiTest {
+        val recorder = RecordingHapticExecutor()
+        val countState = mutableStateOf(2)
+
+        setContent {
+          val count by countState
+          CompositionLocalProvider(LocalHapticExecutor provides recorder) {
+            Jindong(count) {
+              RepeatWithIndex(count) {
+                Haptic(50.ms)
+              }
+            }
+          }
+        }
+
+        waitForIdle()
+        // Initial key = 2 -> RepeatWithIndex emits 2 events.
+        recorder.executedPatterns.last().events.size shouldBe 2
+
+        countState.value = 5
+        waitForIdle()
+
+        // After the key changes to 5, the captured content must recompile to 5 events,
+        // not return the stale first-compile result.
+        recorder.executedPatterns.last().events.size shouldBe 5
+      }
+    }
+  })

--- a/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/executor/RecordingHapticExecutor.kt
+++ b/jindong-compose/src/commonTest/kotlin/io/github/compose/jindong/executor/RecordingHapticExecutor.kt
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.compose.jindong.executor
+
+import io.github.compose.jindong.Jindong
+import io.github.compose.jindong.core.executor.HapticExecutor
+import io.github.compose.jindong.core.executor.HapticHandle
+import io.github.compose.jindong.core.model.HapticPattern
+
+/**
+ * Records executed patterns so a test can inspect what [Jindong] played for a given key.
+ */
+internal class RecordingHapticExecutor : HapticExecutor {
+  override val isSupported: Boolean = true
+
+  val executedPatterns = mutableListOf<HapticPattern>()
+
+  override suspend fun execute(pattern: HapticPattern) {
+    executedPatterns += pattern
+  }
+
+  override fun executeAsync(pattern: HapticPattern): HapticHandle = NoopHapticHandle
+
+  override fun release() = Unit
+
+  internal object NoopHapticHandle : HapticHandle {
+    override val isActive: Boolean = false
+    override fun cancel() = Unit
+  }
+}


### PR DESCRIPTION
## Problem

`Jindong(vararg keys)` is documented to recompile and replay its pattern when keys change, like `LaunchedEffect`. It does not.

`rememberHapticPattern` memoizes with a **keyless** `remember { compilePattern(content) }`, and `Jindong` never threads its `keys` into it. The pattern is compiled once on the first frame and cached forever; `LaunchedEffect(*keys)` then replays that stale pattern on every key change.

As a result, state-driven pattern shape does not work. For example:

```kotlin
Jindong(level) {
    val steps = (level * 10).toInt()
    RepeatWithIndex(steps) { Haptic(50.ms) }
}
```

`steps` is frozen at its first-frame value — changing `level` never changes the emitted event count.

## Fix

- `rememberHapticPattern` takes `vararg keys` and memoizes with `remember(*keys)`.
- `Jindong` threads its `keys` through, so `remember(*keys)` (recompile) and `LaunchedEffect(*keys)` (replay) share the same keys.

An empty key list keeps the previous behavior (compile once, replay once on entry).

## Tests

Adds `JindongReactiveTest` (Compose UI test): a key-driven `steps` that changes the emitted event count. The test fails against the current keyless code and passes after the fix.

Pulls in `compose.ui.test` + `kotlinx-coroutines-test` for `jindong-compose` common tests, run on `iosSimulatorArm64` (the module has no JVM target for Robolectric).

No public API change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for Compose UI testing and coroutine test utilities in shared tests.
* **Bug Fixes**
  * Haptic patterns now correctly refresh when the input keys change, preventing stale memoized haptics.
* **Tests**
  * Added reactive haptic update coverage, including a recording haptic executor helper to verify patterns change as expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->