### PR TITLE
chore: pre-release 1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 <p align="center">
   <a href="https://github.com/user/jindong/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-Apache%202.0-blue.svg" alt="License" /></a>
-  <img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/io.github.compose-jindong/jindong">
+  <a href="https://central.sonatype.com/artifact/io.github.compose-jindong/jindong-compose"><img alt="Maven Central Version" src="https://img.shields.io/maven-central/v/io.github.compose-jindong/jindong-compose?label=maven-central"></a>
   <a href="https://kotlinweekly.net/"><img src="https://img.shields.io/badge/Kotlin%20Weekly-%23493%2C%20%23496-blue.svg" alt="Kotlin Weekly" /></a>
   <a href="https://androidweekly.net/issues/issue-710"><img alt="Badge" height="20px" src="https://androidweekly.net/issues/issue-710/badge"></a>
 </p>

--- a/jindong-compose/build.gradle.kts
+++ b/jindong-compose/build.gradle.kts
@@ -33,7 +33,7 @@ apiValidation {
 }
 
 group = "io.github.compose-jindong"
-version = "1.1.0"
+version = "1.1.1"
 
 kotlin {
     androidLibrary {

--- a/jindong-core/build.gradle.kts
+++ b/jindong-core/build.gradle.kts
@@ -33,7 +33,7 @@ apiValidation {
 }
 
 group = "io.github.compose-jindong"
-version = "1.1.0"
+version = "1.1.1"
 
 kotlin {
   androidLibrary {


### PR DESCRIPTION
Bumps `jindong-core` and `jindong-compose` to 1.1.1 for the patch release.

Since 1.1.0 the only library change on main is the keyless-pattern recompile fix (#84), so this is a patch. Merging this, then publishing the 1.1.1 GitHub release, triggers the Maven Central publish workflow.

No API surface change — `apiCheck` passes and both targets compile.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the project badge in the README to point to the current artifact listing and refreshed its label.

* **Chores**
  * Bumped the published project version from `1.1.0` to `1.1.1` across modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->