### PR TITLE
feat(sample): add algebra demo screen

### DIFF
--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/components/JindongScaffold.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/components/JindongScaffold.kt
@@ -62,7 +62,7 @@ import io.github.compose.jindong.sample.theme.JindongTheme
  * App bar layout:
  * - left: back chevron `‹` (only when [screen] is not the hub) tapping [onBack].
  * - center: [Screen.title] (the Home title doubles as the wordmark).
- * - right: a mono counter (`진동` on Home, else `NN / 07`) plus a 30x30 theme toggle (`☾` light /
+ * - right: a mono counter (`진동` on Home, else `NN / <module count>`) plus a 30x30 theme toggle (`☾` light /
  *   `☀` dark) calling [onToggleTheme]. Both controls keep a >= 48dp hit area.
  *
  * The body uses [Dimens.screenPadH] horizontal padding, [Dimens.bodyTop] top and [Dimens.bodyBottom]
@@ -177,7 +177,7 @@ private fun AppBar(
       verticalAlignment = Alignment.CenterVertically,
     ) {
       Text(
-        text = if (screen.index == 0) "진동" else "${pad2(screen.index)} / 07",
+        text = if (screen.index == 0) "진동" else "${pad2(screen.index)} / ${pad2(Screen.modules.size)}",
         style = JindongTheme.typography.monoMicro.copy(fontWeight = FontWeight.Normal),
         color = colors.text3,
       )

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/nav/AppRoot.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/nav/AppRoot.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import io.github.compose.jindong.sample.components.JindongScaffold
+import io.github.compose.jindong.sample.screens.AlgebraScreen
 import io.github.compose.jindong.sample.screens.HomeScreen
 import io.github.compose.jindong.sample.screens.IntensityLabScreen
 import io.github.compose.jindong.sample.screens.PresetGalleryScreen
@@ -34,7 +35,7 @@ import io.github.compose.jindong.sample.screens.TimingScreen
 import io.github.compose.jindong.sample.theme.JindongTheme
 
 /**
- * Single-level navigation host. Home lists the seven modules; tapping one swaps [current], the app
+ * Single-level navigation host. Home lists the feature modules; tapping one swaps [current], the app
  * bar back chevron returns to Home. The theme follows the system preference unless [darkOverride] is
  * set by the app-bar toggle.
  *
@@ -69,6 +70,7 @@ fun AppRoot() {
         Screen.RepeatIdx -> RepeatWithIndexScreen()
         Screen.Preset -> PresetGalleryScreen()
         Screen.Reactive -> ReactiveScreen()
+        Screen.Algebra -> AlgebraScreen()
       }
     }
   }

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/nav/Screen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/nav/Screen.kt
@@ -16,8 +16,8 @@
 package io.github.compose.jindong.sample.nav
 
 /**
- * Harness destinations. [Home] is the hub (index 0); [modules] lists the seven feature screens that
- * Home links to, in display order. [index] doubles as the app-bar counter value ("NN / 07").
+ * Harness destinations. [Home] is the hub (index 0); [modules] lists the feature screens that
+ * Home links to, in display order. [index] doubles as the app-bar counter value ("NN / <count>").
  */
 sealed interface Screen {
   val routeId: String
@@ -81,8 +81,15 @@ sealed interface Screen {
     override val subtitle = "State-driven · no buttons ★"
   }
 
+  data object Algebra : Screen {
+    override val routeId = "algebra"
+    override val title = "Algebra"
+    override val index = 8
+    override val subtitle = "Transform a pattern, see the diff"
+  }
+
   companion object {
     val modules: List<Screen> =
-      listOf(Single, Intensity, Timing, Repeat, RepeatIdx, Preset, Reactive)
+      listOf(Single, Intensity, Timing, Repeat, RepeatIdx, Preset, Reactive, Algebra)
   }
 }

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/AlgebraScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/AlgebraScreen.kt
@@ -1,0 +1,165 @@
+/*
+ * Copyright (C) 2026 compose-jindong
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.github.compose.jindong.sample.screens
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.text.SpanStyle
+import androidx.compose.ui.text.buildAnnotatedString
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.withStyle
+import androidx.compose.ui.unit.dp
+import io.github.compose.jindong.Jindong
+import io.github.compose.jindong.dsl.Clip
+import io.github.compose.jindong.sample.components.HapticTimeline
+import io.github.compose.jindong.sample.components.MonoLabel
+import io.github.compose.jindong.sample.components.PlayButton
+import io.github.compose.jindong.sample.components.PresetChip
+import io.github.compose.jindong.sample.components.ScreenDescription
+import io.github.compose.jindong.sample.components.TimelineMapper
+import io.github.compose.jindong.sample.components.VGap
+import io.github.compose.jindong.sample.components.timelineAccentColor
+import io.github.compose.jindong.sample.theme.Dimens
+import io.github.compose.jindong.sample.theme.JindongTheme
+
+/**
+ * Algebra (handoff 08): a fixed base pattern and the result of one algebra transform, stacked on two
+ * timelines that share a time axis so `reversed()` or `timeStretch(2.0)` — otherwise invisible — read
+ * at a glance. Toggling a transform chip re-derives the lower timeline and re-arms the two Clip
+ * playbacks; this screen doubles as a manual regression harness for the pattern algebra.
+ */
+@Composable
+fun AlgebraScreen(modifier: Modifier = Modifier) {
+  val colors = JindongTheme.colors
+  val accent = timelineAccentColor()
+
+  val base = remember { algebraBasePattern() }
+  var transform by remember { mutableStateOf(AlgebraTransform.None) }
+  var basePlay by remember { mutableIntStateOf(0) }
+  var resultPlay by remember { mutableIntStateOf(0) }
+
+  // Transformed pattern is derived from the fixed base and the selected transform; keyed by the
+  // transform so the lower timeline and the Clip playback stay live as the selection changes.
+  val transformed = remember(transform) { transform.apply(base) }
+
+  // Both timelines share one window (the larger span), so the transform reads as a change against a
+  // fixed axis rather than each plot rescaling itself.
+  val window = algebraWindow(maxOf(base.spanEndMs(), transformed.spanEndMs()))
+  val baseBars = TimelineMapper.toBars(base, window) { accent }
+  val resultBars = TimelineMapper.toBars(transformed, window) { accent }
+
+  Column(modifier = modifier.fillMaxWidth()) {
+    ScreenDescription(
+      buildAnnotatedString {
+        append("A fixed ")
+        withStyle(SpanStyle(color = colors.text, fontWeight = FontWeight.SemiBold)) { append("base") }
+        append(" pattern and its ")
+        withStyle(SpanStyle(color = colors.text, fontWeight = FontWeight.SemiBold)) { append("transform") }
+        append(". Toggle a chip → the lower timeline shows what the algebra did.")
+      },
+    )
+
+    VGap(16.dp)
+
+    MonoLabel(text = "BASE", modifier = Modifier.padding(bottom = 8.dp))
+    HapticTimeline(
+      bars = baseBars,
+      topLeft = "INTENSITY ▲",
+      topRight = "${base.spanEndMs()} ms",
+      minLabel = "0",
+      maxLabel = window.toString(),
+      playheadProgress = 0f,
+      playheadVisible = false,
+    )
+    VGap(8.dp)
+    PlayButton(onClick = { basePlay++ }, text = "Play base")
+
+    VGap(20.dp)
+
+    MonoLabel(text = "TRANSFORM", modifier = Modifier.padding(bottom = 8.dp))
+    FlowRow(
+      modifier = Modifier.fillMaxWidth(),
+      horizontalArrangement = Arrangement.spacedBy(Dimens.rowGapSmall),
+      verticalArrangement = Arrangement.spacedBy(Dimens.rowGapSmall),
+    ) {
+      AlgebraTransform.entries.forEach { entry ->
+        PresetChip(
+          label = entry.label,
+          selected = entry == transform,
+          onClick = { transform = entry },
+        )
+      }
+    }
+
+    VGap(12.dp)
+
+    ExprLine(expr = transform.expr)
+
+    VGap(18.dp)
+
+    MonoLabel(text = "RESULT", modifier = Modifier.padding(bottom = 8.dp))
+    HapticTimeline(
+      bars = resultBars,
+      topLeft = "INTENSITY ▲",
+      topRight = "${transformed.spanEndMs()} ms",
+      minLabel = "0",
+      maxLabel = window.toString(),
+      playheadProgress = 0f,
+      playheadVisible = false,
+    )
+    VGap(8.dp)
+    PlayButton(onClick = { resultPlay++ }, text = "Play result")
+  }
+
+  // VIBRATION PATH (stale pre-#84; see SingleHapticScreen for the rationale). Playback goes through
+  // Clip with the pattern threaded into the trigger keys, so each press replays the live value; the
+  // buzz self-heals once #84 lands. The timelines above are always live.
+  Jindong(basePlay, base) { Clip(base) }
+  Jindong(resultPlay, transformed) { Clip(transformed) }
+}
+
+/** Mono one-liner showing the algebra expression for the active transform (e.g. `base.reversed()`). */
+@Composable
+private fun ExprLine(expr: String) {
+  val colors = JindongTheme.colors
+  Text(
+    text = expr,
+    style = JindongTheme.typography.monoValue,
+    color = colors.text2,
+    modifier =
+    Modifier
+      .fillMaxWidth()
+      .clip(RoundedCornerShape(Dimens.radiusChip))
+      .background(colors.surface2)
+      .border(Dimens.stroke, colors.border, RoundedCornerShape(Dimens.radiusChip))
+      .padding(horizontal = 12.dp, vertical = 10.dp),
+  )
+}

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/AlgebraScreen.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/AlgebraScreen.kt
@@ -139,9 +139,7 @@ fun AlgebraScreen(modifier: Modifier = Modifier) {
     PlayButton(onClick = { resultPlay++ }, text = "Play result")
   }
 
-  // VIBRATION PATH (stale pre-#84; see SingleHapticScreen for the rationale). Playback goes through
-  // Clip with the pattern threaded into the trigger keys, so each press replays the live value; the
-  // buzz self-heals once #84 lands. The timelines above are always live.
+  // Playback threads the pattern into the trigger keys, so each press replays the live value.
   Jindong(basePlay, base) { Clip(base) }
   Jindong(resultPlay, transformed) { Clip(transformed) }
 }

--- a/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/HarnessLogic.kt
+++ b/sample/shared/src/commonMain/kotlin/io/github/compose/jindong/sample/screens/HarnessLogic.kt
@@ -16,9 +16,15 @@
 package io.github.compose.jindong.sample.screens
 
 import androidx.compose.ui.graphics.Color
+import io.github.compose.jindong.core.dsl.buildHapticPattern
 import io.github.compose.jindong.core.model.HapticIntensity
 import io.github.compose.jindong.core.model.HapticPattern
 import io.github.compose.jindong.core.model.ScheduledHapticEvent
+import io.github.compose.jindong.core.model.repeated
+import io.github.compose.jindong.core.model.reversed
+import io.github.compose.jindong.core.model.scaleIntensity
+import io.github.compose.jindong.core.model.timeStretch
+import io.github.compose.jindong.core.ms
 import kotlin.math.ceil
 
 // Pure, side-effect-free logic shared across the harness screens. Kept out of the composables so the
@@ -172,3 +178,54 @@ internal fun Preset.toPattern(): HapticPattern = HapticPattern(
     )
   },
 )
+
+/** The pure timeline extent of a pattern (latest event end), mirroring the library-internal spanMs. */
+internal fun HapticPattern.spanEndMs(): Long = events.maxOfOrNull { it.startTimeMs + it.durationMs } ?: 0L
+
+/**
+ * The fixed base pattern for the Algebra screen (handoff 08): an asymmetric strong→weak ramp with
+ * widening gaps. Front-loaded and lopsided so that [reversed] visibly flips it and [timeStretch] /
+ * [scaleIntensity] read at a glance on the timeline.
+ */
+internal fun algebraBasePattern(): HapticPattern = buildHapticPattern {
+  haptic(70.ms, HapticIntensity.Custom(0.9f))
+  delay(80.ms)
+  haptic(50.ms, HapticIntensity.Custom(0.6f))
+  delay(150.ms)
+  haptic(40.ms, HapticIntensity.Custom(0.3f))
+}
+
+/** A single algebra transform the demo can toggle on top of the base pattern (handoff 08). */
+internal enum class AlgebraTransform(
+  val label: String,
+  val expr: String,
+) {
+  None("Identity", "base"),
+  Scale("scaleIntensity", "base.scaleIntensity(0.5)"),
+  Stretch("timeStretch", "base.timeStretch(2.0)"),
+  Reverse("reversed", "base.reversed()"),
+  Repeat("repeated", "base.repeated(3)"),
+}
+
+/** Applies [transform] to [base], returning the transformed pattern the second timeline renders. */
+internal fun AlgebraTransform.apply(base: HapticPattern): HapticPattern = when (this) {
+  AlgebraTransform.None -> base
+  AlgebraTransform.Scale -> base.scaleIntensity(SCALE_FACTOR)
+  AlgebraTransform.Stretch -> base.timeStretch(STRETCH_FACTOR)
+  AlgebraTransform.Reverse -> base.reversed()
+  AlgebraTransform.Repeat -> base.repeated(REPEAT_TIMES)
+}
+
+internal const val SCALE_FACTOR = 0.5f
+internal const val STRETCH_FACTOR = 2.0f
+internal const val REPEAT_TIMES = 3
+
+/**
+ * Timeline window shared by both Algebra timelines so base and result share one time axis and the
+ * transform reads as a change against a fixed scale: `max(600, ceil(maxSpan / 100) * 100)`, where
+ * [maxSpanMs] is the larger of the base and transformed spans.
+ */
+internal fun algebraWindow(maxSpanMs: Long): Long {
+  val rounded = ceil(maxOf(1L, maxSpanMs) / 100.0).toLong() * 100L
+  return maxOf(600L, rounded)
+}


### PR DESCRIPTION
Closes #92.

Adds a screen to the sample harness that shows a base pattern and its transform side by side on the haptic timeline, with chips for `scaleIntensity`, `timeStretch`, `reversed`, and `repeated`. Playback goes through `Clip`.

The base pattern is asymmetric (70ms → 50ms → 40ms with widening gaps), so `reversed()` visibly flips the strong bar to the other end and `timeStretch(2.0)` doubles the span at a glance. This doubles as a manual regression harness for the algebra.

Reuses the existing `HapticTimeline`, chips, and design system. The app-bar module counter was hardcoded to `07`; it now reads `Screen.modules.size` so the eighth screen does not render `08 / 07`.

Android and iOS compile; the screen renders. Vibration feel is left for a physical-device check per the repo's emulator-haptics rule.

Stacked on #90 (base branch `feat/clip-node`).
